### PR TITLE
remove the non-existent id in the results selector

### DIFF
--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -38,7 +38,7 @@ test('navigating to the reverse dependencies page', function(assert) {
     andThen(function() {
         assert.equal(currentURL(), '/crates/nanomsg/reverse_dependencies');
 
-        const $revDep = findWithAssert('#crate-all-reverse-dependencies a[href="/crates/unicorn-rpc"]:first');
+        const $revDep = findWithAssert('a[href="/crates/unicorn-rpc"]:first');
 
         hasText(assert, $revDep, 'unicorn-rpc');
     });


### PR DESCRIPTION
Hi there! Sorry to show up randomly, but @carols10cents pinged me on the twitters and I took a lot at the failing travis build and noticed something that will (hopefully) be an easy fix. The test that's been failing is (I'm assuming) attempting to scope the `find` function using by specifying an `id` as part of the selector, e.g. `#crate-all-reverse-dependencies`.

This is definitely a common practice in Ember-qunit land, but in this case that `id` doesn't appear to actually exist anywhere.

I know some other things have been going on with qunit and some weird upgrade issues, but I suspect that in this case, the strange `assert.async` error you were seeing is simply a case of a bad error message for a relatively simple fluke.

Anyway, I've pulled out the `id` for now. If you decided you want to re-scope them, we could scope on the parent class, `white-rows`, but that's a style-related class so it feels weird. Otherwise we can just add an id or data-attribute to scope on if need be.